### PR TITLE
Fix #45: None link type was not working

### DIFF
--- a/includes/class-arconix-portfolio-metaboxes.php
+++ b/includes/class-arconix-portfolio-metaboxes.php
@@ -48,8 +48,8 @@ class Arconix_Portfolio_Metaboxes {
 				'desc'             => esc_html__( 'Set the hyperlink value for the portfolio item', 'acp' ),
 				'id'               => '_acp_link_type',
 				'type'             => 'select',
-				'show_option_none' => true,
 				'options'          => array(
+					'none'	   => esc_html__( 'None', 'acp' ),
 					'image'    => esc_html__( 'Image', 'acp' ),
 					'page'     => esc_html__( 'Page', 'acp' ),
 					'external' => esc_html__( 'External', 'acp' ),

--- a/includes/class-arconix-portfolio-public.php
+++ b/includes/class-arconix-portfolio-public.php
@@ -313,6 +313,7 @@ class Arconix_Portfolio {
 		$id          = get_the_ID();
 		$extra_class = apply_filters( 'arconix_portfolio_external_link_class', '' );
 		$url         = $this->get_portfolio_hyperlink( $link, $full );
+		$s = '';
 		if ( ! $link ) {
 			$link = get_post_meta( $id, '_acp_link_type', true );
 		}


### PR DESCRIPTION
Fixed the error where the 'None' link type was not working and redirecting the portfolio to image.